### PR TITLE
feat: add dis.army to blocked list

### DIFF
--- a/domains/domains.json
+++ b/domains/domains.json
@@ -277,6 +277,7 @@
   "dfscord-app.club",
   "dfscord-app.com",
   "dfscord.com",
+  "dis.army",
   "diacord.com",
   "diacordapp.com",
   "diascord.com",


### PR DESCRIPTION
We are running a disocrd server for our product's community and there are many spammers. Our bot deletes messages. Example message:

![image](https://github.com/user-attachments/assets/e8048246-446f-4d93-9017-7db55d080118)


They have their own page that returns 301 to discord invite page and it is not detected as discord invitation

```
>  tmp curl -i https://dis.army
HTTP/2 301
date: Sat, 28 Sep 2024 14:22:03 GMT
content-length: 0
location: https://discord.com/invite/ZnZ3nxZMuq
server: domain-forward
strict-transport-security: max-age=31536000; preload
```